### PR TITLE
Fix stats recording in game results

### DIFF
--- a/src/main/java/com/auroraschaos/minigames/game/GameInstance.java
+++ b/src/main/java/com/auroraschaos/minigames/game/GameInstance.java
@@ -251,6 +251,9 @@ public abstract class GameInstance {
         }
         player.sendMessage("§eYou have left " + type + " [" + gameMode + "].");
 
+        // Record a loss for the departing player immediately
+        statsManager.recordLoss(player.getUniqueId(), type);
+
         // 5) Notify remaining participants
         for (Player p : participants) {
             p.sendMessage("§c" + player.getName() + " has left the game!");
@@ -258,17 +261,10 @@ public abstract class GameInstance {
 
         // 6) If only one (or zero) participants remain, end the game early
         if (participants.size() <= 1) {
-            // If one player remains, declare them the winner and record stats
+            // If one player remains, simply announce the winner.
             if (participants.size() == 1) {
                 Player winner = participants.get(0);
                 winner.sendMessage("§6You are the winner of " + type + "!");
-                statsManager.recordWin(winner.getUniqueId(), type);
-            }
-            // Record losses for any who remain in "participants" (if any)
-            for (Player p : participants) {
-                if (participants.size() == 0 || !p.equals(participants.get(0))) {
-                    statsManager.recordLoss(p.getUniqueId(), type);
-                }
             }
             // End the match
             stop();

--- a/src/main/java/com/auroraschaos/minigames/stats/StatsManager.java
+++ b/src/main/java/com/auroraschaos/minigames/stats/StatsManager.java
@@ -96,14 +96,22 @@ public class StatsManager {
     // -------------------
 
     public void recordGameResult(GameInstance instance) {
+        if (instance.getParticipants().isEmpty()) {
+            return;
+        }
+
+        Player winner = null;
         // Default logic: last survivor is winner
         if (instance.getParticipants().size() == 1) {
-            UUID winnerId = instance.getParticipants().get(0).getUniqueId();
-            recordWin(winnerId, instance.getType());
+            winner = instance.getParticipants().get(0);
+            recordWin(winner.getUniqueId(), instance.getType());
         }
-        // Everyone else is a loser
+
+        // Everyone except the winner is a loser
         for (Player p : instance.getParticipants()) {
-            recordLoss(p.getUniqueId(), instance.getType());
+            if (winner == null || !p.equals(winner)) {
+                recordLoss(p.getUniqueId(), instance.getType());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- fix StatsManager so winners aren't also counted as losers
- record a loss when a player leaves a game
- stop recording stats twice when a game ends early

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852bdfd88bc833095b84b578c04beab