### PR TITLE
Initialize arenas and add stats saving

### DIFF
--- a/src/main/java/com/auroraschaos/minigames/MinigamesPlugin.java
+++ b/src/main/java/com/auroraschaos/minigames/MinigamesPlugin.java
@@ -87,7 +87,12 @@ public class MinigamesPlugin extends JavaPlugin {
      */
     @Override
     public void onDisable() {
-        // TODO: Save data, clean up tasks
+        if (arenaService != null) {
+            arenaService.shutdownAll();
+        }
+        if (statsManager != null) {
+            statsManager.save();
+        }
         getLogger().info("MinigamesPlugin has been disabled!");
     }
 
@@ -136,6 +141,9 @@ public class MinigamesPlugin extends JavaPlugin {
             guiManager
         );
         queueSB = new QueueScoreboardManager(this, gameManager);
+
+        // Load and register arenas from configuration
+        arenaService.initializeAll();
     }
 
     private Map<String, List<GameMode>> modesPerGame = new HashMap<>();

--- a/src/main/java/com/auroraschaos/minigames/commands/MinigamesCommand.java
+++ b/src/main/java/com/auroraschaos/minigames/commands/MinigamesCommand.java
@@ -3,6 +3,7 @@ package com.auroraschaos.minigames.commands;
 import org.bukkit.ChatColor;
 import org.bukkit.command.*;
 import org.bukkit.entity.Player;
+import org.bukkit.Bukkit;
 
 import com.auroraschaos.minigames.MinigamesPlugin;
 import com.auroraschaos.minigames.game.GameManager;
@@ -166,11 +167,23 @@ public class MinigamesCommand implements CommandExecutor, TabCompleter {
      * @param args   The command arguments. Optionally includes a target player name.
      */
     private void handleStats(Player player, String[] args) {
-        if (args.length == 1) {
-            player.sendMessage(ChatColor.YELLOW + "Your stats: (not implemented)");
-        } else {
-            String targetName = args[1];
-            player.sendMessage(ChatColor.YELLOW + "Stats for " + targetName + ": (not implemented)");
+        Player target = player;
+        if (args.length >= 2) {
+            target = Bukkit.getPlayer(args[1]);
+            if (target == null) {
+                player.sendMessage(ChatColor.RED + "Player not found.");
+                return;
+            }
+        }
+
+        UUID id = target.getUniqueId();
+        player.sendMessage(ChatColor.AQUA + "--- Stats for " + target.getName() + " ---");
+        for (String key : plugin.getConfig().getConfigurationSection("minigames").getKeys(false)) {
+            int wins = plugin.getStatsManager().getWins(id, key.toUpperCase());
+            int losses = plugin.getStatsManager().getLosses(id, key.toUpperCase());
+            int plays = wins + losses;
+            player.sendMessage(ChatColor.YELLOW + key.toUpperCase() + ChatColor.WHITE + ": " +
+                    "Wins " + wins + ", Losses " + losses + ", Plays " + plays);
         }
     }
 

--- a/src/main/java/com/auroraschaos/minigames/stats/StatsManager.java
+++ b/src/main/java/com/auroraschaos/minigames/stats/StatsManager.java
@@ -155,6 +155,19 @@ public class StatsManager {
         return getWins(playerUUID, gameType) + getLosses(playerUUID, gameType);
     }
 
+    /**
+     * Persist any pending statistic changes to disk or database.
+     * This should be invoked when the plugin shuts down to avoid
+     * losing data.
+     */
+    public void save() {
+        if (statsConfig.getStorageType() == StatsConfig.StorageType.FLATFILE) {
+            saveFlatfile();
+        } else {
+            // TODO: flush to SQL backend when implemented
+        }
+    }
+
     // -------------------
     // Helpers
     // -------------------


### PR DESCRIPTION
## Summary
- initialize arenas from config when plugin loads
- persist stats on plugin disable
- expose a save method in `StatsManager`
- show real stats in the `/minigames stats` command

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852c0e5f4988330b54ebd3c0b381038