### PR TITLE
Remove unused default kart config method

### DIFF
--- a/src/main/java/com/auroraschaos/minigames/game/race/TrackConfig.java
+++ b/src/main/java/com/auroraschaos/minigames/game/race/TrackConfig.java
@@ -59,7 +59,4 @@ public class TrackConfig {
         return config.contains(path);
     }
 
-    public KartConfig getDefaultKartConfig() {
-        throw new UnsupportedOperationException("Unimplemented method 'getDefaultKartConfig'");
-    }
 }


### PR DESCRIPTION
## Summary
- remove unused `getDefaultKartConfig` from TrackConfig

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852c3a9c9f88330924e7d9cf7caed8e