### PR TITLE
Rename method to getArenaService

### DIFF
--- a/src/main/java/com/auroraschaos/minigames/MinigamesPlugin.java
+++ b/src/main/java/com/auroraschaos/minigames/MinigamesPlugin.java
@@ -215,10 +215,11 @@ public class MinigamesPlugin extends JavaPlugin {
     }
 
     /**
-     * Gets the ArenaManager responsible for managing arena schematics and instances.
-     * @return The ArenaManager instance.
+     * Gets the {@link ArenaService} responsible for managing arena schematics and instances.
+     *
+     * @return The arena service instance.
      */
-    public ArenaService getArenaManager() {
+    public ArenaService getArenaService() {
         return arenaService;
     }
 

--- a/src/main/java/com/auroraschaos/minigames/game/GameInstance.java
+++ b/src/main/java/com/auroraschaos/minigames/game/GameInstance.java
@@ -269,7 +269,7 @@ public abstract class GameInstance {
             // End the match
             stop();
             // Reset and free the arena
-            plugin.getArenaManager().resetArena(arena);
+            plugin.getArenaService().resetArena(arena);
             arena.setInUse(false);
             Bukkit.getLogger().info("Game " + id + " (" + type + ") ended early due to too few players.");
         }

--- a/src/main/java/com/auroraschaos/minigames/game/GameManager.java
+++ b/src/main/java/com/auroraschaos/minigames/game/GameManager.java
@@ -25,7 +25,7 @@ import java.util.*;
 /**
  * GameManager is responsible for:
  *  1. Managing player queues for each minigame (with optional GameMode).
- *  2. Spinning up dynamic Arena instances on demand via ArenaManager.
+ *  2. Spinning up dynamic Arena instances on demand via ArenaService.
  *  3. Tracking ongoing GameInstance objects (one per running game).
  *  4. Handling game start/end lifecycle events.
  *


### PR DESCRIPTION
## Summary
- rename method `getArenaManager()` to `getArenaService()` in `MinigamesPlugin`
- adjust `GameInstance` to call the new method
- clarify docs referencing `ArenaService`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852c3aa787483308c20f0c8eca7ebdf