### PR TITLE
Remove unused fields

### DIFF
--- a/src/main/java/com/auroraschaos/minigames/arena/ArenaService.java
+++ b/src/main/java/com/auroraschaos/minigames/arena/ArenaService.java
@@ -15,10 +15,6 @@ import java.util.Map;
 public class ArenaService {
     private final MinigamesPlugin plugin;
     private final ArenaDefinitionRepository definitionRepo;
-    @SuppressWarnings("unused")
-    private final SlotAllocator slotAllocator;
-    @SuppressWarnings("unused")
-    private final SchematicLoader schematicLoader;
     private final ArenaFactory arenaFactory;
     private final ArenaRegistry registry;
     private final ArenaResetService resetService;
@@ -30,8 +26,6 @@ public class ArenaService {
                         ArenaResetService resetService) {
         this.plugin        = plugin;
         this.definitionRepo= new ArenaDefinitionRepository(config);
-        this.slotAllocator = slotAllocator;
-        this.schematicLoader = schematicLoader;
         this.arenaFactory  = new ArenaFactory(slotAllocator, schematicLoader);
         this.registry      = new ArenaRegistry();
         this.resetService  = resetService;

--- a/src/main/java/com/auroraschaos/minigames/util/SpectatorUtil.java
+++ b/src/main/java/com/auroraschaos/minigames/util/SpectatorUtil.java
@@ -3,7 +3,6 @@ package com.auroraschaos.minigames.util;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.util.BoundingBox;
 
 import com.auroraschaos.minigames.arena.Arena;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -51,10 +50,8 @@ public class SpectatorUtil {
             originVec.getY() + 50,
             originVec.getZ() + 100
         );
-        @SuppressWarnings("unused")
-        BoundingBox box = BoundingBox.of(minLoc, maxLoc);
-        // If you need to store this box somewhere or schedule a repeating task 
-        // to clamp players to this box, you can do so here.
+        // Calculate bounds players should be clamped to. Implement clamping
+        // logic later using BoundingBox.of(minLoc, maxLoc).
 
         p.setCollidable(false);
     }


### PR DESCRIPTION
## Summary
- remove unused fields from `ArenaService`
- delete unused bounding box and suppression in `SpectatorUtil`

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6852c3abf4b08330ad3468e4f81bfb66