### PR TITLE
Remove duplicate stats update

### DIFF
--- a/src/main/java/com/auroraschaos/minigames/game/GameManager.java
+++ b/src/main/java/com/auroraschaos/minigames/game/GameManager.java
@@ -440,9 +440,6 @@ public class GameManager {
         arenaService.resetArena(arena);
         arena.setInUse(false);
 
-        // 3) Update stats via StatsManager
-        statsManager.recordGameResult(instance);
-
         plugin.getLogger().info("Ended game " + instanceId + " (" + instance.getType() + ")");
     }
 


### PR DESCRIPTION
## Summary
- rely on `GameInstance.stop()` to record statistics
- remove extra `recordGameResult` call in `GameManager.endGame`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852c3a6d8ac8330afc6c64892ae0171