### PR TITLE
Add Spleef config via ConfigManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Minecraft Version](https://img.shields.io/badge/Spigot-1.13%2B-green)](https://www.spigotmc.org/) [![Java Version](https://img.shields.io/badge/Java-8%2B-brightgreen)](https://www.oracle.com/java/) [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-A **modular**, **extensible**, and **fun** Minigames plugin for Spigot/Bukkit Minecraft servers. Out-of-the-box support for **TNT Run** and **SkyWars**, plus:
+A **modular**, **extensible**, and **fun** Minigames plugin for Spigot/Bukkit Minecraft servers. Out-of-the-box support for **TNT Run**, **SkyWars**, and **Spleef**, plus:
 
 - ❇️ Party system (team up to queue together)  
 - 🗓️ Flexible queue & countdown with action-bars & scoreboards  
@@ -15,8 +15,9 @@ A **modular**, **extensible**, and **fun** Minigames plugin for Spigot/Bukkit Mi
 
 ## 🚀 Features
 
-- **TNT Run**: Dynamic floor destruction, per-arena timer & “Players Left” sidebar.  
-- **SkyWars**: WE schematic paste, chest loot tables, ring-shrinking arena, random events.  
+- **TNT Run**: Dynamic floor destruction, per-arena timer & “Players Left” sidebar.
+- **SkyWars**: WE schematic paste, chest loot tables, ring-shrinking arena, random events.
+- **Spleef**: Break snow blocks or launch snowballs to drop opponents; last player standing wins.
 - **Party System**: Create/invite/disband parties with colored name-tag teams.  
 - **Queue Management**: Min/max players, 60s countdown, chat & action-bar updates.  
 - **Scoreboards**:  

--- a/src/main/java/com/auroraschaos/minigames/MinigamesPlugin.java
+++ b/src/main/java/com/auroraschaos/minigames/MinigamesPlugin.java
@@ -264,4 +264,11 @@ public class MinigamesPlugin extends JavaPlugin {
     public QueueScoreboardManager getQueueScoreboardManager(){
         return queueSB;
     }
+
+    /**
+     * Provides access to the central ConfigManager containing all plugin settings.
+     */
+    public ConfigManager getConfigManager() {
+        return configManager;
+    }
 }

--- a/src/main/java/com/auroraschaos/minigames/config/ConfigManager.java
+++ b/src/main/java/com/auroraschaos/minigames/config/ConfigManager.java
@@ -15,6 +15,7 @@ public class ConfigManager {
     private GameModeConfig gameModeConfig;
     private PartyConfig partyConfig;
     private StatsConfig statsConfig;
+    private SpleefConfig spleefConfig;
     //private GuiConfig guiConfig;
     //private ScoreboardConfig scoreboardConfig;
     //private CountdownConfig countdownConfig;
@@ -40,6 +41,7 @@ public class ConfigManager {
         gameModeConfig    = parseGameModeConfig();
         partyConfig       = parsePartyConfig();
         statsConfig       = parseStatsConfig();
+        spleefConfig      = parseSpleefConfig();
         //guiConfig         = parseGuiConfig();
         //scoreboardConfig  = parseScoreboardConfig();
         //countdownConfig   = parseCountdownConfig();
@@ -74,6 +76,16 @@ public class ConfigManager {
             throw new ConfigurationException("Missing '" + path + "' section in config.yml");
         }
         return StatsConfig.from(config.getConfigurationSection(path));
+    }
+
+    private SpleefConfig parseSpleefConfig() throws ConfigurationException {
+        java.io.File file = new java.io.File(plugin.getDataFolder(), "Spleef.yml");
+        if (!file.exists()) {
+            plugin.saveResource("Spleef.yml", false);
+        }
+        org.bukkit.configuration.file.YamlConfiguration cfg =
+            org.bukkit.configuration.file.YamlConfiguration.loadConfiguration(file);
+        return SpleefConfig.from(cfg);
     }
 /**
     private GuiConfig parseGuiConfig() throws ConfigurationException {
@@ -114,6 +126,7 @@ public class ConfigManager {
     public GameModeConfig getGameModeConfig() { return gameModeConfig; }
     public PartyConfig getPartyConfig() { return partyConfig; }
     public StatsConfig getStatsConfig() { return statsConfig; }
+    public SpleefConfig getSpleefConfig() { return spleefConfig; }
     //public GuiConfig getGuiConfig() { return guiConfig; }
     //public ScoreboardConfig getScoreboardConfig() { return scoreboardConfig; }
     //public CountdownConfig getCountdownConfig() { return countdownConfig; }

--- a/src/main/java/com/auroraschaos/minigames/config/SpleefConfig.java
+++ b/src/main/java/com/auroraschaos/minigames/config/SpleefConfig.java
@@ -1,0 +1,54 @@
+package com.auroraschaos.minigames.config;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration values for the Spleef minigame loaded from Spleef.yml.
+ */
+public class SpleefConfig {
+    private final int spawnYOffset;
+    private final int gameDuration;
+    private final int snowballCooldown;
+    private final List<Material> breakableBlocks;
+
+    private SpleefConfig(int spawnYOffset, int gameDuration, int snowballCooldown,
+                         List<Material> breakableBlocks) {
+        this.spawnYOffset = spawnYOffset;
+        this.gameDuration = gameDuration;
+        this.snowballCooldown = snowballCooldown;
+        this.breakableBlocks = List.copyOf(breakableBlocks);
+    }
+
+    /**
+     * Parse the supplied YAML configuration to a {@code SpleefConfig} instance.
+     */
+    public static SpleefConfig from(YamlConfiguration cfg) throws ConfigurationException {
+        if (cfg == null) {
+            throw new ConfigurationException("Spleef configuration is missing");
+        }
+        int offset = cfg.getInt("spawn_y_offset", 10);
+        int duration = cfg.getInt("game_duration", 300);
+        int cooldown = cfg.getInt("snowball_cooldown", 1);
+        List<String> rawBlocks = cfg.getStringList("breakable_blocks");
+        if (rawBlocks.isEmpty()) {
+            rawBlocks = List.of("SNOW_BLOCK", "SNOW");
+        }
+        List<Material> blocks = new ArrayList<>();
+        for (String s : rawBlocks) {
+            Material m = Material.matchMaterial(s);
+            if (m == null) {
+                throw new ConfigurationException("Unknown material '" + s + "' in breakable_blocks");
+            }
+            blocks.add(m);
+        }
+        return new SpleefConfig(offset, duration, cooldown, blocks);
+    }
+
+    public int getSpawnYOffset() { return spawnYOffset; }
+    public int getGameDuration() { return gameDuration; }
+    public int getSnowballCooldown() { return snowballCooldown; }
+    public List<Material> getBreakableBlocks() { return breakableBlocks; }
+}

--- a/src/main/java/com/auroraschaos/minigames/game/GameManager.java
+++ b/src/main/java/com/auroraschaos/minigames/game/GameManager.java
@@ -4,6 +4,7 @@ import com.auroraschaos.minigames.MinigamesPlugin;
 import com.auroraschaos.minigames.arena.Arena;
 import com.auroraschaos.minigames.arena.ArenaService;
 import com.auroraschaos.minigames.game.race.RaceGame;
+import com.auroraschaos.minigames.game.SpleefGame;
 import com.auroraschaos.minigames.gui.GUIManager;
 import com.auroraschaos.minigames.party.PartyManager;
 import com.auroraschaos.minigames.stats.StatsManager;
@@ -397,6 +398,9 @@ public class GameManager {
         switch (type.toUpperCase()) {
             case "TNT_RUN":
                 instance = new TNTRunGame(type, mode, plugin, arena, players);
+                break;
+            case "SPLEEF":
+                instance = new SpleefGame(type, mode, plugin, arena, players);
                 break;
             case "RACE":
                 try {

--- a/src/main/java/com/auroraschaos/minigames/game/SpleefGame.java
+++ b/src/main/java/com/auroraschaos/minigames/game/SpleefGame.java
@@ -1,0 +1,243 @@
+package com.auroraschaos.minigames.game;
+
+import com.auroraschaos.minigames.MinigamesPlugin;
+import com.auroraschaos.minigames.arena.Arena;
+import com.auroraschaos.minigames.scoreboard.ScoreboardManager;
+import com.auroraschaos.minigames.util.CountdownTimer;
+import com.auroraschaos.minigames.util.SpectatorUtil;
+
+import com.auroraschaos.minigames.config.SpleefConfig;
+
+import com.sk89q.worldedit.math.BlockVector3;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Snowball;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.block.Action;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Basic Spleef implementation following the style of {@link TNTRunGame}.
+ * Players spawn on a snow platform and receive shovels to break blocks
+ * beneath opponents. Falling into the void eliminates a player. The
+ * last remaining player wins or the game ends when time expires.
+ */
+public class SpleefGame extends GameInstance implements Listener {
+
+    /** Height offset from arena origin for spawn location. */
+    private final int spawnYOffset;
+
+    /** Total round duration in seconds. */
+    private final int gameDuration;
+
+    /** Cooldown between snowball throws in seconds. */
+    private final int snowballCooldown;
+
+    /** Block types snowballs can break. */
+    private final List<Material> breakableBlocks = new ArrayList<>();
+
+    /** Last time a player threw a snowball (ms) */
+    private final Map<Player, Long> lastThrow = new HashMap<>();
+
+    private final List<Player> alivePlayers = new ArrayList<>();
+    private final List<Player> spectators   = new ArrayList<>();
+
+    private final ScoreboardManager scoreboardManager;
+    private final CountdownTimer countdownTimer;
+
+    /** Periodic task that checks win condition. */
+    private BukkitTask checkTask;
+
+    public SpleefGame(String type,
+                      GameMode gameMode,
+                      MinigamesPlugin plugin,
+                      Arena arena,
+                      List<Player> participants) {
+        super(plugin, arena, type, gameMode, participants);
+        this.scoreboardManager = plugin.getScoreboardManager();
+        this.countdownTimer    = plugin.getCountdownTimer();
+
+        // Load configuration via ConfigManager
+        SpleefConfig cfg = plugin.getConfigManager().getSpleefConfig();
+        this.spawnYOffset = cfg.getSpawnYOffset();
+        this.gameDuration = cfg.getGameDuration();
+        this.snowballCooldown = cfg.getSnowballCooldown();
+        this.breakableBlocks.addAll(cfg.getBreakableBlocks());
+    }
+
+    @Override
+    protected void onGameStart() {
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+
+        BlockVector3 originVec = arena.getOrigin();
+        Location spawn = new Location(
+                arena.getWorld(),
+                originVec.getX() + 0.5,
+                originVec.getY() + spawnYOffset,
+                originVec.getZ() + 0.5
+        );
+
+        // Prepare scoreboard
+        scoreboardManager.getOrCreateScoreboard(getId());
+        scoreboardManager.setScoreLine(getId(), "title_" + getId(), "§dSpleef", 4);
+        scoreboardManager.setScoreLine(getId(), "players_" + getId(),
+                "Players Left: " + participants.size(), 3);
+
+        for (Player p : participants) {
+            alivePlayers.add(p);
+            p.teleport(spawn);
+            p.getInventory().clear();
+            p.getInventory().addItem(new ItemStack(Material.DIAMOND_SHOVEL));
+            scoreboardManager.showToPlayer(getId(), p);
+            p.playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
+        }
+
+        countdownTimer.startCountdown(getId(), gameDuration);
+
+        checkTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                // Update scoreboard
+                scoreboardManager.setScoreLine(getId(), "players_" + getId(),
+                        "Players Left: " + alivePlayers.size(), 3);
+
+                if (alivePlayers.size() <= 1) {
+                    announceWinner();
+                    plugin.getGameManager().endGame(getId());
+                    cancel();
+                }
+            }
+        }.runTaskTimer(plugin, 20L, 20L);
+    }
+
+    @Override
+    protected void onGameEnd() {
+        HandlerList.unregisterAll(this);
+        if (checkTask != null) checkTask.cancel();
+        countdownTimer.cancelCountdown(getId());
+
+        for (Player p : participants) {
+            scoreboardManager.removeFromPlayer(p);
+        }
+        for (Player p : spectators) {
+            scoreboardManager.removeFromPlayer(p);
+            SpectatorUtil.returnToLobby(p,
+                    plugin.getServer().getWorlds().get(0).getSpawnLocation());
+        }
+        scoreboardManager.clearArenaScoreboard(getId());
+        lastThrow.clear();
+    }
+
+    @Override
+    protected boolean requiresTicks() {
+        return false;
+    }
+
+    @Override
+    protected void tick() {
+        // unused
+    }
+
+    private void announceWinner() {
+        if (alivePlayers.isEmpty()) {
+            broadcastMessage("§eNo winners this round.");
+        } else {
+            Player winner = alivePlayers.get(0);
+            broadcastMessage("§a" + winner.getName() + " wins Spleef!");
+            winner.playSound(winner.getLocation(),
+                    Sound.UI_TOAST_CHALLENGE_COMPLETE, 1f, 1f);
+        }
+    }
+
+    private void eliminatePlayer(Player p) {
+        if (!alivePlayers.remove(p)) return;
+        SpectatorUtil.makeSpectator(p, arena);
+        spectators.add(p);
+        scoreboardManager.showToPlayer(getId(), p);
+        p.sendMessage("§cYou were eliminated!");
+        p.playSound(p.getLocation(), Sound.ENTITY_ELDER_GUARDIAN_CURSE, 1f, 0.5f);
+    }
+
+    // ---------------------- Event Handlers ----------------------
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player p = event.getPlayer();
+        if (!alivePlayers.contains(p)) return;
+        Block b = event.getBlock();
+        Material type = b.getType();
+        if (type != Material.SNOW_BLOCK && type != Material.SNOW) {
+            event.setCancelled(true);
+        } else {
+            event.setDropItems(false);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        Player p = event.getPlayer();
+        if (!alivePlayers.contains(p)) return;
+        if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            if (p.getInventory().getItemInMainHand().getType() == Material.DIAMOND_SHOVEL) {
+                long now = System.currentTimeMillis();
+                long last = lastThrow.getOrDefault(p, 0L);
+                if (now - last >= snowballCooldown * 1000L) {
+                    lastThrow.put(p, now);
+                    p.launchProjectile(Snowball.class);
+                    p.playSound(p.getLocation(), Sound.ENTITY_SNOWBALL_THROW, 1f, 1f);
+                }
+            }
+        }
+    }
+
+    @EventHandler
+    public void onProjectileHit(ProjectileHitEvent event) {
+        if (!(event.getEntity() instanceof Snowball)) return;
+        if (!(event.getEntity().getShooter() instanceof Player)) return;
+        Player shooter = (Player) event.getEntity().getShooter();
+        if (!alivePlayers.contains(shooter)) return;
+
+        Block hit = event.getHitBlock();
+        if (hit != null && breakableBlocks.contains(hit.getType())) {
+            hit.setType(Material.AIR);
+        }
+    }
+
+    @EventHandler
+    public void onVoidDamage(EntityDamageEvent event) {
+        if (event.getCause() != EntityDamageEvent.DamageCause.VOID) return;
+        if (!(event.getEntity() instanceof Player)) return;
+        Player p = (Player) event.getEntity();
+        if (!alivePlayers.contains(p)) return;
+        event.setCancelled(true);
+        eliminatePlayer(p);
+    }
+
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event) {
+        Player p = event.getPlayer();
+        if (!alivePlayers.contains(p)) return;
+        if (p.getLocation().getY() < arena.getOrigin().getY() - 1) {
+            eliminatePlayer(p);
+        }
+    }
+}
+

--- a/src/main/resources/Spleef.yml
+++ b/src/main/resources/Spleef.yml
@@ -1,0 +1,8 @@
+# Global Spleef settings
+
+spawn_y_offset: 10          # height offset above arena origin for spawns
+game_duration: 300          # round length in seconds
+snowball_cooldown: 1        # seconds between snowball throws
+breakable_blocks:
+  - SNOW_BLOCK
+  - SNOW


### PR DESCRIPTION
## Summary
- create `SpleefConfig` to hold Spleef settings
- load `Spleef.yml` inside `ConfigManager`
- expose `ConfigManager` from `MinigamesPlugin`
- fetch config in `SpleefGame` instead of loading YAML directly

## Testing
- `mvn -q -DskipTests install` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852c5c40408833086b28e4e3ad5b17e