### PR TITLE
Add verbose logging for arena loading

### DIFF
--- a/src/main/java/com/auroraschaos/minigames/arena/ArenaDefinitionRepository.java
+++ b/src/main/java/com/auroraschaos/minigames/arena/ArenaDefinitionRepository.java
@@ -20,6 +20,13 @@ public class ArenaDefinitionRepository {
                 e -> e.getKey().toLowerCase(),
                 Map.Entry::getValue
             ));
+
+        com.auroraschaos.minigames.MinigamesPlugin.getInstance().getLogger().info(
+            String.format(
+                "[ArenaConfig] Repository initialised with %d arenas",
+                this.definitions.size()
+            )
+        );
     }
 
     public Optional<ArenaDefinition> get(String key) {

--- a/src/main/java/com/auroraschaos/minigames/arena/ArenaFactory.java
+++ b/src/main/java/com/auroraschaos/minigames/arena/ArenaFactory.java
@@ -19,23 +19,42 @@ public class ArenaFactory {
         this.schematicLoader = schematicLoader;
     }
 
-    public Arena create(MinigamesPlugin plugin, ArenaDefinition def) throws ArenaCreationException {
+    public Arena create(MinigamesPlugin plugin, ArenaDefinition def)
+            throws ArenaCreationException {
         World world = plugin.getServer().getWorld(def.getWorldName());
         if (world == null) {
             throw new ArenaCreationException(
-                "World '" + def.getWorldName() + "' not found for arena '" + def.getKey() + "'."
+                "World '" + def.getWorldName() + "' not found for arena '"
+                    + def.getKey() + "'."
             );
         }
+
+        plugin.getLogger().info(String.format(
+            "[ArenaFactory] Allocating slot for '%s' in world '%s'",
+            def.getKey(), world.getName()
+        ));
+
         Vector originVec = slotAllocator.nextSlot(world);
         BlockVector3 origin = BlockVector3.at(
             originVec.getBlockX(), originVec.getBlockY(), originVec.getBlockZ()
         );
 
+        plugin.getLogger().info(String.format(
+            "[ArenaFactory] Pasting schematic '%s' at %s",
+            def.getSchematic(), originVec
+        ));
+
         try {
             schematicLoader.loadSchematic(def.getSchematic(), world, originVec);
         } catch (Exception e) {
+            plugin.getLogger().log(
+                java.util.logging.Level.WARNING,
+                "[ArenaFactory] Failed to paste schematic",
+                e
+            );
             throw new ArenaCreationException(
-                "Failed to load schematic '" + def.getSchematic() + "'.", e
+                "Failed to load schematic '" + def.getSchematic() + "'.",
+                e
             );
         }
 

--- a/src/main/java/com/auroraschaos/minigames/arena/ArenaService.java
+++ b/src/main/java/com/auroraschaos/minigames/arena/ArenaService.java
@@ -41,26 +41,43 @@ public class ArenaService {
      * Instantiate all arenas defined in config and register them.
      */
     public void initializeAll() {
+        plugin.getLogger().info("[ArenaService] Starting arena initialization...");
+        plugin.getLogger().info(String.format(
+            "[ArenaService] %d arena definitions found.",
+            definitionRepo.getAll().size()
+        ));
+
         for (ArenaDefinition def : definitionRepo.getAll()) {
+            plugin.getLogger().info(String.format(
+                "[ArenaService] Preparing arena '%s' (world=%s, schematic=%s)",
+                def.getKey(), def.getWorldName(), def.getSchematic()
+            ));
+
             try {
                 Arena arena = arenaFactory.create(plugin, def);
                 registry.register(arena);
-                // Schedule its auto-reset
                 resetService.scheduleReset(arena, def.getResetIntervalTicks());
-                plugin.getLogger().info(
-                    String.format("[ArenaService] Registered arena '%s' at %s",
-                        arena.getName(), arena.getOrigin())
-                );
+                plugin.getLogger().info(String.format(
+                    "[ArenaService] Registered arena '%s' at %s",
+                    arena.getName(), arena.getOrigin()
+                ));
             } catch (ArenaCreationException ex) {
-                plugin.getLogger().warning(
-                    String.format("[ArenaService] Failed to create arena '%s': %s",
-                        def.getKey(), ex.getMessage())
+                plugin.getLogger().log(
+                    java.util.logging.Level.WARNING,
+                    String.format(
+                        "[ArenaService] Failed to create arena '%s'",
+                        def.getKey()
+                    ),
+                    ex
                 );
             }
         }
-        plugin.getLogger().info(
-            String.format("[ArenaService] Initialized %d arenas.", registry.count())
-        );
+
+        plugin.getLogger().info(String.format(
+            "[ArenaService] Initialized %d arenas.",
+            registry.count()
+        ));
+        plugin.getLogger().info("[ArenaService] Arena initialization complete.");
     }
 
     /**  

--- a/src/main/java/com/auroraschaos/minigames/config/ArenaConfig.java
+++ b/src/main/java/com/auroraschaos/minigames/config/ArenaConfig.java
@@ -16,16 +16,32 @@ public class ArenaConfig {
         this.arenas = Collections.unmodifiableMap(arenas);
     }
 
-    public static ArenaConfig from(ConfigurationSection section) throws ConfigurationException {
+    public static ArenaConfig from(ConfigurationSection section)
+            throws ConfigurationException {
         if (section == null) {
             throw new ConfigurationException("'arenas' section is missing");
         }
+
+        java.util.logging.Logger log =
+            com.auroraschaos.minigames.MinigamesPlugin.getInstance().getLogger();
+
+        log.info("[ArenaConfig] Loading arena definitions...");
+
         Map<String, ArenaDefinition> map = new HashMap<>();
         for (String key : section.getKeys(false)) {
             ConfigurationSection sec = section.getConfigurationSection(key);
-            if (sec == null) continue;
+            if (sec == null) {
+                log.warning("[ArenaConfig] Section for '" + key + "' is missing");
+                continue;
+            }
             map.put(key.toLowerCase(), ArenaDefinition.from(sec));
         }
+
+        log.info(String.format(
+            "[ArenaConfig] Loaded %d arena definitions",
+            map.size()
+        ));
+
         return new ArenaConfig(map);
     }
 

--- a/src/main/java/com/auroraschaos/minigames/config/ArenaDefinition.java
+++ b/src/main/java/com/auroraschaos/minigames/config/ArenaDefinition.java
@@ -28,12 +28,16 @@ public class ArenaDefinition {
         this.resetIntervalTicks = resetIntervalTicks;
     }
 
-    public static ArenaDefinition from(ConfigurationSection sec) throws ConfigurationException {
+    public static ArenaDefinition from(ConfigurationSection sec)
+            throws ConfigurationException {
         String key = sec.getName().toLowerCase();
         String schematic = sec.getString("schematic");
         if (schematic == null || schematic.isEmpty()) {
-            throw new ConfigurationException("Missing 'schematic' for arena: " + key);
+            throw new ConfigurationException(
+                "Missing 'schematic' for arena: " + key
+            );
         }
+
         String world = sec.getString("world", "minigames_world");
         Map<String, String> flagsMap = new HashMap<>();
         ConfigurationSection flagsSec = sec.getConfigurationSection("flags");
@@ -41,14 +45,25 @@ public class ArenaDefinition {
             for (String flagName : flagsSec.getKeys(false)) {
                 String value = flagsSec.getString(flagName);
                 if (value == null) {
-                    throw new ConfigurationException("Flag '" + flagName +
-                        "' for arena '" + key + "' is null");
+                    throw new ConfigurationException(
+                        "Flag '" + flagName + "' for arena '" + key + "' is null"
+                    );
                 }
                 flagsMap.put(flagName.toUpperCase(), value.toUpperCase());
             }
         }
+
         long intervalSec = sec.getLong("resetIntervalSeconds", 60L);
         long intervalTicks = intervalSec * 20L;
+
+        com.auroraschaos.minigames.MinigamesPlugin.getInstance().getLogger().info(
+            String.format(
+                "[ArenaConfig] Parsed arena '%s' world=%s schematic=%s",
+                key,
+                world,
+                schematic
+            )
+        );
 
         return new ArenaDefinition(key, schematic, world, flagsMap, intervalTicks);
     }


### PR DESCRIPTION
## Summary
- emit detailed logs when creating arenas
- log schematic and slot allocation steps
- show loaded arena definitions during config parsing
- log parsed arena definitions
- log repository initialization details

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685511dc0d1483308b50579d2edae8e8