### PR TITLE
Add verbose logs across managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ plugins/
 ### `config.yml`
 
 ```yaml
+verboseLogging: false
 minigames:
   TNT_RUN:
     display_name: "&aTNT Run"
@@ -89,6 +90,8 @@ minigames:
       - SOLO
       - TEAMS
 ```
+
+Enable `verboseLogging` to output additional debug information to the console.
 
 ### `SkyWars.yml`
 

--- a/src/main/java/com/auroraschaos/minigames/MinigamesPlugin.java
+++ b/src/main/java/com/auroraschaos/minigames/MinigamesPlugin.java
@@ -271,4 +271,15 @@ public class MinigamesPlugin extends JavaPlugin {
     public ConfigManager getConfigManager() {
         return configManager;
     }
+
+    /**
+     * Log a debug message when verboseLogging is enabled.
+     *
+     * @param message text to log
+     */
+    public void logVerbose(String message) {
+        if (configManager != null && configManager.isVerboseLogging()) {
+            getLogger().info("[VERBOSE] " + message);
+        }
+    }
 }

--- a/src/main/java/com/auroraschaos/minigames/arena/ArenaDefinitionRepository.java
+++ b/src/main/java/com/auroraschaos/minigames/arena/ArenaDefinitionRepository.java
@@ -21,7 +21,7 @@ public class ArenaDefinitionRepository {
                 Map.Entry::getValue
             ));
 
-        com.auroraschaos.minigames.MinigamesPlugin.getInstance().getLogger().info(
+        com.auroraschaos.minigames.MinigamesPlugin.getInstance().logVerbose(
             String.format(
                 "[ArenaConfig] Repository initialised with %d arenas",
                 this.definitions.size()

--- a/src/main/java/com/auroraschaos/minigames/arena/ArenaFactory.java
+++ b/src/main/java/com/auroraschaos/minigames/arena/ArenaFactory.java
@@ -29,7 +29,7 @@ public class ArenaFactory {
             );
         }
 
-        plugin.getLogger().info(String.format(
+        plugin.logVerbose(String.format(
             "[ArenaFactory] Allocating slot for '%s' in world '%s'",
             def.getKey(), world.getName()
         ));
@@ -39,7 +39,7 @@ public class ArenaFactory {
             originVec.getBlockX(), originVec.getBlockY(), originVec.getBlockZ()
         );
 
-        plugin.getLogger().info(String.format(
+        plugin.logVerbose(String.format(
             "[ArenaFactory] Pasting schematic '%s' at %s",
             def.getSchematic(), originVec
         ));

--- a/src/main/java/com/auroraschaos/minigames/arena/ArenaService.java
+++ b/src/main/java/com/auroraschaos/minigames/arena/ArenaService.java
@@ -41,14 +41,14 @@ public class ArenaService {
      * Instantiate all arenas defined in config and register them.
      */
     public void initializeAll() {
-        plugin.getLogger().info("[ArenaService] Starting arena initialization...");
-        plugin.getLogger().info(String.format(
+        plugin.logVerbose("[ArenaService] Starting arena initialization...");
+        plugin.logVerbose(String.format(
             "[ArenaService] %d arena definitions found.",
             definitionRepo.getAll().size()
         ));
 
         for (ArenaDefinition def : definitionRepo.getAll()) {
-            plugin.getLogger().info(String.format(
+            plugin.logVerbose(String.format(
                 "[ArenaService] Preparing arena '%s' (world=%s, schematic=%s)",
                 def.getKey(), def.getWorldName(), def.getSchematic()
             ));
@@ -57,7 +57,7 @@ public class ArenaService {
                 Arena arena = arenaFactory.create(plugin, def);
                 registry.register(arena);
                 resetService.scheduleReset(arena, def.getResetIntervalTicks());
-                plugin.getLogger().info(String.format(
+                plugin.logVerbose(String.format(
                     "[ArenaService] Registered arena '%s' at %s",
                     arena.getName(), arena.getOrigin()
                 ));
@@ -73,11 +73,11 @@ public class ArenaService {
             }
         }
 
-        plugin.getLogger().info(String.format(
+        plugin.logVerbose(String.format(
             "[ArenaService] Initialized %d arenas.",
             registry.count()
         ));
-        plugin.getLogger().info("[ArenaService] Arena initialization complete.");
+        plugin.logVerbose("[ArenaService] Arena initialization complete.");
     }
 
     /**  

--- a/src/main/java/com/auroraschaos/minigames/config/ArenaConfig.java
+++ b/src/main/java/com/auroraschaos/minigames/config/ArenaConfig.java
@@ -22,25 +22,24 @@ public class ArenaConfig {
             throw new ConfigurationException("'arenas' section is missing");
         }
 
-        java.util.logging.Logger log =
-            com.auroraschaos.minigames.MinigamesPlugin.getInstance().getLogger();
-
-        log.info("[ArenaConfig] Loading arena definitions...");
+        com.auroraschaos.minigames.MinigamesPlugin.getInstance()
+            .logVerbose("[ArenaConfig] Loading arena definitions...");
 
         Map<String, ArenaDefinition> map = new HashMap<>();
         for (String key : section.getKeys(false)) {
             ConfigurationSection sec = section.getConfigurationSection(key);
             if (sec == null) {
-                log.warning("[ArenaConfig] Section for '" + key + "' is missing");
+                com.auroraschaos.minigames.MinigamesPlugin.getInstance()
+                    .getLogger()
+                    .warning("[ArenaConfig] Section for '" + key + "' is missing");
                 continue;
             }
             map.put(key.toLowerCase(), ArenaDefinition.from(sec));
         }
 
-        log.info(String.format(
-            "[ArenaConfig] Loaded %d arena definitions",
-            map.size()
-        ));
+        com.auroraschaos.minigames.MinigamesPlugin.getInstance().logVerbose(
+            String.format("[ArenaConfig] Loaded %d arena definitions", map.size())
+        );
 
         return new ArenaConfig(map);
     }

--- a/src/main/java/com/auroraschaos/minigames/config/ArenaDefinition.java
+++ b/src/main/java/com/auroraschaos/minigames/config/ArenaDefinition.java
@@ -56,7 +56,7 @@ public class ArenaDefinition {
         long intervalSec = sec.getLong("resetIntervalSeconds", 60L);
         long intervalTicks = intervalSec * 20L;
 
-        com.auroraschaos.minigames.MinigamesPlugin.getInstance().getLogger().info(
+        com.auroraschaos.minigames.MinigamesPlugin.getInstance().logVerbose(
             String.format(
                 "[ArenaConfig] Parsed arena '%s' world=%s schematic=%s",
                 key,

--- a/src/main/java/com/auroraschaos/minigames/config/ConfigManager.java
+++ b/src/main/java/com/auroraschaos/minigames/config/ConfigManager.java
@@ -1,7 +1,7 @@
 package com.auroraschaos.minigames.config;
 
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
+import com.auroraschaos.minigames.MinigamesPlugin;
 import java.util.Map;
 
 import com.auroraschaos.minigames.config.TTTConfig;
@@ -10,7 +10,7 @@ import com.auroraschaos.minigames.config.TTTConfig;
  * Central manager for loading and validating all plugin configuration files.
  */
 public class ConfigManager {
-    private final JavaPlugin plugin;
+    private final MinigamesPlugin plugin;
     private final FileConfiguration config;
 
     private ArenaConfig arenaConfig;
@@ -25,7 +25,10 @@ public class ConfigManager {
     //private QueueConfig queueConfig;
     // ... other sub-configs as needed
 
-    public ConfigManager(JavaPlugin plugin) {
+    /** Whether verbose logging is enabled via config.yml. */
+    private boolean verboseLogging;
+
+    public ConfigManager(MinigamesPlugin plugin) {
         this.plugin = plugin;
         this.plugin.saveDefaultConfig();
         this.config = plugin.getConfig();
@@ -41,16 +44,32 @@ public class ConfigManager {
         }
         // Parse each section
         arenaConfig       = parseArenaConfig();
+        plugin.logVerbose("[ConfigManager] Arena config loaded with "
+                + arenaConfig.getArenas().size() + " arenas");
+
         gameModeConfig    = parseGameModeConfig();
+        plugin.logVerbose("[ConfigManager] Game mode config loaded");
+
         partyConfig       = parsePartyConfig();
+        plugin.logVerbose("[ConfigManager] Party config loaded");
+
         statsConfig       = parseStatsConfig();
+        plugin.logVerbose("[ConfigManager] Stats config loaded");
+
         spleefConfig      = parseSpleefConfig();
+        plugin.logVerbose("[ConfigManager] Spleef config loaded");
+
         tttConfig         = parseTTTConfig();
+        plugin.logVerbose("[ConfigManager] TTT config loaded");
         //guiConfig         = parseGuiConfig();
         //scoreboardConfig  = parseScoreboardConfig();
         //countdownConfig   = parseCountdownConfig();
         //queueConfig       = parseQueueConfig();
         // Add more as plugin evolves
+
+        // Root-level options
+        verboseLogging = config.getBoolean("verboseLogging", false);
+        plugin.logVerbose("[ConfigManager] verboseLogging=" + verboseLogging);
     }
 
     private ArenaConfig parseArenaConfig() throws ConfigurationException {
@@ -142,6 +161,8 @@ public class ConfigManager {
     public StatsConfig getStatsConfig() { return statsConfig; }
     public SpleefConfig getSpleefConfig() { return spleefConfig; }
     public TTTConfig getTTTConfig() { return tttConfig; }
+    /** @return true if verbose logging is enabled. */
+    public boolean isVerboseLogging() { return verboseLogging; }
     //public GuiConfig getGuiConfig() { return guiConfig; }
     //public ScoreboardConfig getScoreboardConfig() { return scoreboardConfig; }
     //public CountdownConfig getCountdownConfig() { return countdownConfig; }

--- a/src/main/java/com/auroraschaos/minigames/game/GameInstance.java
+++ b/src/main/java/com/auroraschaos/minigames/game/GameInstance.java
@@ -271,7 +271,7 @@ public abstract class GameInstance {
             // Reset and free the arena
             plugin.getArenaService().resetArena(arena);
             arena.setInUse(false);
-            Bukkit.getLogger().info("Game " + id + " (" + type + ") ended early due to too few players.");
+            plugin.logVerbose("Game " + id + " (" + type + ") ended early due to too few players.");
         }
     }
 }

--- a/src/main/java/com/auroraschaos/minigames/game/GameManager.java
+++ b/src/main/java/com/auroraschaos/minigames/game/GameManager.java
@@ -103,7 +103,7 @@ public class GameManager {
         QueueEntry entry = new QueueEntry(entrants);
         queue.add(entry);
         plugin.getQueueScoreboardManager().updateQueueScoreboard(type, mode);
-        plugin.getLogger().info("Enqueued " + entrants.size()
+        plugin.logVerbose("Enqueued " + entrants.size()
                 + " player(s) for " + type + " [" + mode + "]");
 
         // Notify the entrants via chat
@@ -202,6 +202,8 @@ public class GameManager {
 
         toRemove.sendMessage(ChatColor.RED + "You left the queue for "
                 + type + " [" + mode + "].");
+        plugin.logVerbose("[GameManager] " + toRemove.getName()
+                + " dequeued from " + type + " [" + mode + "]");
 
         // Update the action-bar for everyone still in queue
         updateQueueActionBar(type, queue);
@@ -252,6 +254,8 @@ public class GameManager {
         // Inform queue that countdown has begun
         broadcastToQueue(queue, ChatColor.GREEN + "Minimum players reached! "
                 + "Game starts in " + COUNTDOWN_SECONDS + " seconds...");
+        plugin.logVerbose(String.format(
+                "[GameManager] Countdown started for %s [%s]", type, mode));
 
         // Create a repeating task that runs once per second (20 ticks)
         BukkitTask task = new BukkitRunnable() {
@@ -263,6 +267,8 @@ public class GameManager {
                 int currentSize = queue.size();
                 if (currentSize < getMinPlayers(type)) {
                     broadcastToQueue(queue, ChatColor.RED + "Countdown aborted: not enough players.");
+                    plugin.logVerbose(String.format(
+                            "[GameManager] Countdown aborted for %s [%s]", type, mode));
                     cancel();
                     countdownTasks.remove(key);
                     return;
@@ -289,6 +295,8 @@ public class GameManager {
                     }
                     queueMap.remove(key);
 
+                    plugin.logVerbose(String.format(
+                            "[GameManager] Countdown finished for %s [%s]", type, mode));
                     startNewGame(type, mode, participants);
                     return;
                 }
@@ -309,6 +317,7 @@ public class GameManager {
         if (task != null && !task.isCancelled()) {
             task.cancel();
         }
+        plugin.logVerbose("[GameManager] Countdown cancelled for key " + key);
     }
 
     /**
@@ -423,7 +432,7 @@ public class GameManager {
         // 3) Register & start the instance
         activeGames.put(instance.getId(), instance);
         instance.start();
-        plugin.getLogger().info("Started " + type + " [" + mode + "] with ID: " + instance.getId());
+        plugin.logVerbose("Started " + type + " [" + mode + "] with ID: " + instance.getId());
     }
 
     /**
@@ -443,7 +452,7 @@ public class GameManager {
         arenaService.resetArena(arena);
         arena.setInUse(false);
 
-        plugin.getLogger().info("Ended game " + instanceId + " (" + instance.getType() + ")");
+        plugin.logVerbose("Ended game " + instanceId + " (" + instance.getType() + ")");
     }
 
     // ------------------------------------------------------------

--- a/src/main/java/com/auroraschaos/minigames/game/SkyWarsGame.java
+++ b/src/main/java/com/auroraschaos/minigames/game/SkyWarsGame.java
@@ -136,6 +136,9 @@ public class SkyWarsGame extends GameInstance implements Listener {
         // 8) Start event scheduling and arena shrinking
         startEventSchedule();
         startShrinkSchedule();
+        plugin.logVerbose(String.format(
+                "[SkyWarsGame] Started with %d players on %s",
+                participants.size(), arena.getName()));
     }
 
     @Override
@@ -152,6 +155,7 @@ public class SkyWarsGame extends GameInstance implements Listener {
             spec.teleport(plugin.getServer().getWorlds().get(0).getSpawnLocation());
             spec.setGameMode(org.bukkit.GameMode.SURVIVAL);
         }
+        plugin.logVerbose("[SkyWarsGame] Ended on arena " + arena.getName());
     }
 
     @Override

--- a/src/main/java/com/auroraschaos/minigames/game/SpleefGame.java
+++ b/src/main/java/com/auroraschaos/minigames/game/SpleefGame.java
@@ -126,6 +126,9 @@ public class SpleefGame extends GameInstance implements Listener {
                 }
             }
         }.runTaskTimer(plugin, 20L, 20L);
+        plugin.logVerbose(String.format(
+                "[SpleefGame] Started with %d players on %s",
+                participants.size(), arena.getName()));
     }
 
     @Override
@@ -144,6 +147,7 @@ public class SpleefGame extends GameInstance implements Listener {
         }
         scoreboardManager.clearArenaScoreboard(getId());
         lastThrow.clear();
+        plugin.logVerbose("[SpleefGame] Ended on arena " + arena.getName());
     }
 
     @Override
@@ -174,6 +178,7 @@ public class SpleefGame extends GameInstance implements Listener {
         scoreboardManager.showToPlayer(getId(), p);
         p.sendMessage("§cYou were eliminated!");
         p.playSound(p.getLocation(), Sound.ENTITY_ELDER_GUARDIAN_CURSE, 1f, 0.5f);
+        plugin.logVerbose("[SpleefGame] Player eliminated: " + p.getName());
     }
 
     // ---------------------- Event Handlers ----------------------

--- a/src/main/java/com/auroraschaos/minigames/game/TNTRunGame.java
+++ b/src/main/java/com/auroraschaos/minigames/game/TNTRunGame.java
@@ -106,6 +106,9 @@ public class TNTRunGame extends GameInstance implements Listener {
 
         // 5) Schedule block removal & game logic
         setupRemovalTask();
+        plugin.logVerbose(String.format(
+                "[TNTRunGame] Started with %d players on %s",
+                participants.size(), arena.getName()));
     }
 
     @Override
@@ -133,6 +136,7 @@ public class TNTRunGame extends GameInstance implements Listener {
             SpectatorUtil.returnToLobby(spec,
                 plugin.getServer().getWorlds().get(0).getSpawnLocation());
         }
+        plugin.logVerbose("[TNTRunGame] Ended on arena " + arena.getName());
     }
 
     @Override
@@ -164,6 +168,7 @@ public class TNTRunGame extends GameInstance implements Listener {
             // 3) Notify elimination
             p.sendMessage("§cYou have been eliminated! Now in Spectator mode.");
             p.playSound(p.getLocation(), Sound.ENTITY_ELDER_GUARDIAN_CURSE, 1.0f, 0.5f);
+            plugin.logVerbose("[TNTRunGame] Player eliminated: " + p.getName());
         }
     }
 

--- a/src/main/java/com/auroraschaos/minigames/game/TTTGame.java
+++ b/src/main/java/com/auroraschaos/minigames/game/TTTGame.java
@@ -120,6 +120,9 @@ public class TTTGame extends GameInstance implements Listener {
                 }
             }
         }.runTaskTimer(plugin, 20L, 20L);
+        plugin.logVerbose(String.format(
+                "[TTTGame] Started with %d players on %s",
+                participants.size(), arena.getName()));
     }
 
     @Override
@@ -136,6 +139,7 @@ public class TTTGame extends GameInstance implements Listener {
         }
         scoreboardManager.clearArenaScoreboard(getId());
         shop.unregister();
+        plugin.logVerbose("[TTTGame] Ended on arena " + arena.getName());
     }
 
     @EventHandler
@@ -197,6 +201,7 @@ public class TTTGame extends GameInstance implements Listener {
         scoreboardManager.showToPlayer(getId(), p);
         p.sendMessage("§cYou were eliminated!");
         checkWinCondition();
+        plugin.logVerbose("[TTTGame] Player eliminated: " + p.getName());
     }
 
     private void checkWinCondition() {

--- a/src/main/java/com/auroraschaos/minigames/game/race/RaceGame.java
+++ b/src/main/java/com/auroraschaos/minigames/game/race/RaceGame.java
@@ -99,6 +99,9 @@ public class RaceGame extends GameInstance {
                 launchRaceLoop();
             }
         }.runTaskLater(plugin, secs * 20L);
+        plugin.logVerbose(String.format(
+                "[RaceGame] Started with %d players on %s",
+                participants.size(), arena.getName()));
     }
 
     private void launchRaceLoop() {
@@ -152,6 +155,7 @@ public class RaceGame extends GameInstance {
         // End in GameManager
         plugin.getStatsManager().recordGameResult(this);
         plugin.getGameManager().endGame(getId());
+        plugin.logVerbose("[RaceGame] Ended on arena " + arena.getName());
     }
 
     @Override

--- a/src/main/java/com/auroraschaos/minigames/party/PartyManager.java
+++ b/src/main/java/com/auroraschaos/minigames/party/PartyManager.java
@@ -75,6 +75,9 @@ public class PartyManager {
         // Create a scoreboard Team for this party
         registerPartyTeam(party);
 
+        plugin.logVerbose("[PartyManager] Created party " + party.getId()
+                + " with leader " + leader.getName());
+
         return party;
     }
 
@@ -103,6 +106,7 @@ public class PartyManager {
         if (team != null) {
             team.unregister();
         }
+        plugin.logVerbose("[PartyManager] Disbanded party " + partyId);
     }
 
     // ----------------------------------------------------------------
@@ -133,6 +137,8 @@ public class PartyManager {
         if (team != null) {
             team.addEntry(invitee.getName());
         }
+        plugin.logVerbose("[PartyManager] Added " + invitee.getName()
+                + " to party " + partyId);
         return true;
     }
 
@@ -167,6 +173,8 @@ public class PartyManager {
         if (party.isEmpty()) {
             disbandParty(partyId);
         }
+        plugin.logVerbose("[PartyManager] Removed " + member.getName()
+                + " from party " + partyId);
         return true;
     }
 

--- a/src/main/java/com/auroraschaos/minigames/stats/StatsManager.java
+++ b/src/main/java/com/auroraschaos/minigames/stats/StatsManager.java
@@ -71,14 +71,14 @@ public class StatsManager {
         }
 
         statsStorage = YamlConfiguration.loadConfiguration(statsFile);
-        plugin.getLogger().info("[StatsManager] Flatfile storage initialized at " + statsFile);
+        plugin.logVerbose("[StatsManager] Flatfile storage initialized at " + statsFile);
     }
 
     private void initMySqlStorage() {
         // StatsConfig.MySQLConfig cfg = statsConfig.getMysqlConfig();
         // String url = "jdbc:mysql://" + cfg.getHost() + ":" + cfg.getPort() + "/" + cfg.getDatabase();
         // ... set up DataSource ...
-        plugin.getLogger().info("[StatsManager] MySQL storage selected, initialization pending.");
+        plugin.logVerbose("[StatsManager] MySQL storage selected, initialization pending.");
     }
 
     private void scheduleAutoSave() {
@@ -89,7 +89,7 @@ public class StatsManager {
             intervalTicks,
             intervalTicks
         );
-        plugin.getLogger().info("[StatsManager] Scheduled auto-save every "
+        plugin.logVerbose("[StatsManager] Scheduled auto-save every "
             + statsConfig.getAutoSaveIntervalSeconds() + " seconds.");
     }
 
@@ -126,7 +126,7 @@ public class StatsManager {
                 saveFlatfile();
             }
         } else {
-            plugin.getLogger().info("[StatsManager] (MySQL) recordWin for " + playerUUID + " in " + gameType);
+            plugin.logVerbose("[StatsManager] (MySQL) recordWin for " + playerUUID + " in " + gameType);
         }
     }
 
@@ -139,7 +139,7 @@ public class StatsManager {
                 saveFlatfile();
             }
         } else {
-            plugin.getLogger().info("[StatsManager] (MySQL) recordLoss for " + playerUUID + " in " + gameType);
+            plugin.logVerbose("[StatsManager] (MySQL) recordLoss for " + playerUUID + " in " + gameType);
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,4 @@
+verboseLogging: false
 minigames:
   TNT_RUN:
     display_name: "§cTNT Run"


### PR DESCRIPTION
## Summary
- extend verbose logging to game lifecycle and party actions
- report configuration loading details
- log player eliminations in minigames

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855131c26e483308e74d14e3f2af74b