### PR TITLE
Enable loading litematic schematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ plugins/
    │  ├─ Arena2.yml
    │  └─ Defaults.yml
    └─ schematics/
-      └─ your_schematic.schem
+      └─ your_schematic.schem (.litematic also supported)
 ```
 
 ### `config.yml`
@@ -123,7 +123,7 @@ Global timers & event weights. Customize `event_interval`, `shrink_start`, loot-
 
 1. **GameType**: Extend `GameInstance` and override `onGameStart()`, `onGameEnd()`, (and optionally `requiresTicks()/tick()`).  
 2. **Registration**: Update `GameManager#startNewGame(...)` to wire your new class.  
-3. **Arena**: Drop a new `.yml` under `SkyWars/` (or your game folder) and schematic under `schematics/`.  
+3. **Arena**: Drop a new `.yml` under `SkyWars/` (or your game folder) and schematic (`.schem` or `.litematic`) under `schematics/`.
 4. **Submit** a PR—bug fixes, new minigames, docs!  
 
 ---

--- a/src/main/java/com/auroraschaos/minigames/arena/SchematicLoader.java
+++ b/src/main/java/com/auroraschaos/minigames/arena/SchematicLoader.java
@@ -9,6 +9,9 @@ import org.bukkit.util.Vector;
 public interface SchematicLoader {
     /**
      * Load and paste the given schematic at the specified origin in the target world.
+     * The loader supports `.schem`, `.schematic` and `.litematic` files.
+     * The extension may be included in {@code schematicName} or omitted.
+     *
      * @param schematicName filename (or key) of the schematic to load
      * @param world         the Bukkit World instance
      * @param origin        the origin Vector where the schematic is pasted

--- a/src/main/java/com/auroraschaos/minigames/arena/WorldEditSchematicLoader.java
+++ b/src/main/java/com/auroraschaos/minigames/arena/WorldEditSchematicLoader.java
@@ -33,9 +33,24 @@ public class WorldEditSchematicLoader implements SchematicLoader {
     @Override
     public void loadSchematic(String schematicName, World bukkitWorld, Vector originVec)
             throws ArenaCreationException {
-        File schemFile = new File(plugin.getDataFolder(), "schematics/" + schematicName + ".schem");
+        File baseDir = new File(plugin.getDataFolder(), "schematics");
+        File schemFile = new File(baseDir, schematicName);
+
         if (!schemFile.exists()) {
-            throw new ArenaCreationException("Schematic not found: " + schemFile.getAbsolutePath());
+            String[] exts = {".schem", ".schematic", ".litematic"};
+            for (String ext : exts) {
+                File alt = new File(baseDir, schematicName + ext);
+                if (alt.exists()) {
+                    schemFile = alt;
+                    break;
+                }
+            }
+        }
+
+        if (!schemFile.exists()) {
+            throw new ArenaCreationException(
+                "Schematic not found: " + new File(baseDir, schematicName).getAbsolutePath()
+            );
         }
 
         try {


### PR DESCRIPTION
## Summary
- support `.schem`, `.schematic` and `.litematic` files when loading arenas
- document new schematic support in README
- clarify schematic loader API

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685547c297d08330a87b44b59a59045d